### PR TITLE
Added include query option

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,12 @@ Car.where({ make: new RegExp('Aston Martin', 'i') }, { varName: "car" }, functio
 });
 ```
 
+* in(range) statement to specify range of elements to match provide array of elements
+Car.where({ make: ['Aston Martin', 'Toyota', 'BMW'] }, { varName: "car"}, function(err, cars) {
+  // `cars` will match the result as in `IN ['Aston Martin', 'Toyota', 'BMW']` cypher query
+});
+``` 
+
 `opts` is a set of options to pass to the [query](#query) call. Special options
 for `where`:
 
@@ -806,12 +812,16 @@ all Cars with an age greater than `x` years. I might do a query like this:
   own MATCHes when you have non-composed relations. `include` should be an object,
   where each key is the name of the property on the resulting node, and each value
   is an object with the following options:
+  * `where` object that will specify query condition for the relationship ex. `where: { name: 'John' }`
   * `model` the seraph-model that will be read
   * `relName` the name/label of the relationship relating the root node and this model
   * `direction` (optional - default: `out`) the direction of the relationship
     (valid options are: `in`, `out` or `many`).
+  * `strict` (optional - default: 'false') if set to `true` will perform `MATCH`
+    instead of `OPTIONAL MATCH` while quering relations 
   * `many` (optional - default: `false`) if set to true, the result is always
     and array
+  
 * `computeLevels` - compute computed variables on models up to this depth in the
   composition graph. This may be desirable if you are reading many nodes, and
   you have computations that cause a database query to be executed. This can

--- a/lib/match.js
+++ b/lib/match.js
@@ -1,0 +1,38 @@
+function getMatchers(predicate, opts) {
+  return Object.keys(predicate).map(function(key) {
+    if (predicate[key] instanceof RegExp) {
+      predicate[key] = '(?isu)' + predicate[key].source;
+
+      return `${opts.varName}.${key} =~ {${opts.varName}_${key}}`;
+    }
+
+    if (Array.isArray(predicate[key])) {
+      return `${opts.varName}.${key} in {${opts.varName}_${key}}`;
+    }
+
+    return `${opts.varName}.${key} = {${opts.varName}_${key}}`;
+  });
+}
+
+function composeWhere(matchers, opts) {
+  return `WHERE ${matchers.join(opts.any ? ' OR ' : ' AND ')}`;
+}
+
+function extendPredicate(predicate, matchCondition, relVarName) {
+  if (!matchCondition) { return predicate; }
+  
+  const predicateExtension = Object.keys(matchCondition).reduce(function(obj, key) {
+    obj[`${relVarName}_${key}`] = matchCondition[key];
+
+    return obj;
+  }, {});
+  const extendedPredicate = Object.assign({}, predicate, predicateExtension);
+
+  return extendedPredicate;
+}
+
+module.exports = {
+  getMatchers: getMatchers,
+  composeWhere: composeWhere,
+  extendPredicate: extendPredicate
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -4,6 +4,8 @@ var _ = require('underscore');
 var moment = require('moment');
 var createSchemaParser = require('./schema');
 var getId = require('./get-id');
+var getMatchers = require('./match').getMatchers;
+var composeWhere = require('./match').composeWhere;
 
 function Model(seraphDb, type) {
   var self = this;
@@ -225,6 +227,7 @@ Model.prototype.findAll = function(opts, callback) {
     callback = opts;
     opts = {};
   }
+
   this.read(null, opts, callback);
 }
 
@@ -253,16 +256,10 @@ Model.prototype.where = function(predicate, opts, callback) {
 
   opts.varName = opts.varName || 'node';
 
-  var matchers = Object.keys(predicate).map(function(key) {
-    if (predicate[key] instanceof RegExp) {
-      predicate[key] = '(?isu)' + predicate[key].source;
-      return opts.varName + '.' + key + ' =~ {' + key + '}';
-    }
-    return opts.varName + '.' + key + ' = {' + key + '}';
-  });
-
+  var matchers = getMatchers(predicate, opts);
+  var whereCondition = composeWhere(matchers, opts);
   var query = 'MATCH (' + opts.varName + ':' + this.type + ') ' +
-              'WHERE ' + matchers.join(opts.any ? ' OR ' : ' AND ')
+              whereCondition;
 
   this.query(query, predicate, opts, callback);
 }

--- a/lib/read.js
+++ b/lib/read.js
@@ -4,6 +4,20 @@ var transformComps = require('./transform-composed-nodes'),
     compositionRelationCypherList = require('./composition-relation-cypher-list'),
     sortComps = require('./sort-compositions'),
     getId = require('./get-id');
+var getMatchers = require('./match').getMatchers;
+var composeWhere = require('./match').composeWhere;
+var extendPredicate = require('./match').extendPredicate;
+
+
+function getIncludeQuery(options) {
+  if (!options.where) {
+    return '';
+  }
+  
+  var matchers = getMatchers(options.where, options);
+
+  return composeWhere(matchers, options);
+}
 
 function assembleReadQuery(opts) {
   opts.depth = opts.depth == null ? 2 : opts.depth;
@@ -71,13 +85,25 @@ function assembleReadQuery(opts) {
   if (opts.include) {
     Object.keys(opts.include).forEach(function(include) {
       var includeOpts = opts.include[include];
-
+      var relVarName = `__sm_inc_${include}`
+      var inclWhereOptions = Object.assign({}, includeOpts, { varName: relVarName });
+      var includeWhereCondition = getIncludeQuery(inclWhereOptions);
       var rel = '-[:`' + includeOpts.relName + '`]-'
+      var matchType = includeOpts.strict ? 'MATCH' : 'OPTIONAL MATCH';
+
+      if (includeOpts.where) {
+        var indcludePredicate = extendPredicate(opts.params, includeOpts.where, relVarName);
+        Object.assign(opts.params, indcludePredicate);
+      }
+
       if (includeOpts.direction == 'in') rel = '<' + rel;
       else if(includeOpts.direction != 'any') rel += '>';
 
-      query.push('OPTIONAL MATCH (' + opts.varName + ')' + rel +
-                 '(__sm_inc_' + include + ':' + includeOpts.model.type + ')');
+      query.push(`${matchType} (${opts.varName})${rel}(${relVarName}:${includeOpts.model.type})`);
+
+      if (includeWhereCondition) {
+        query.push(includeWhereCondition);
+      }
     });
   }
 
@@ -203,6 +229,7 @@ module.exports = {
     if (typeof opts == 'number') opts = { depth: opts };
 
     opts.rootId = node == null ? null : getId(this.db, node);
+    opts.params = extendPredicate(opts.params, opts.params, opts.varName);
 
     var query = assembleReadQuery.call(this, opts);
 


### PR DESCRIPTION
Adds option to write a condition for the include query so that one can make a call as follows
Adds `strict` property that changes `OPTIONAL MATCH` to `MATCH` for relationship selection if set to `true`

```js
const opts = {
  varName: 'person',
  include: {
    'Student': {
      model: Student, // assume imported at the top
      relName: 'IS_STUDENT_OF',
      many: true,
      strict: true,
      where: { university: 'LP' }
    }
  }
};
Person.findAll(opts, function(err, results) {
  // will result return only Persons that have a relation to Student with a `university` property === 'LP'   
})
```
supports multiple include queries
Additionally this PR adds `in` option for the query condition, example with multiple queries and `in` statement below

```js
const opts = {
  varName: 'person',
  include: {
    'Student': {
      model: Student, // assume imported at the top
      relName: 'IS_STUDENT_OF',
      many: true,
      strict: true,
      where: { university: 'LP' }
    },
    'City': {
      model: City, // assume imported at the top
      relName: 'IS_CITY',
      many: true,
      strict: true,
      where: { name: ['Lviv', 'Kyiv', 'Bergen'] }
    }
  }
};
Person.findAll(opts, function(err, results) {
  // will result return only Persons that have a relation to Student with a `university` property === 'LP' 
  // and with has relation to City with `name` value in `['Lviv', 'Kyiv', 'Bergen']`
})
```

if `strict` option is not set `OPTIONAL MATCH` will be performed, so that all the records for the Person will be returned, and only those that have relation will be extended.
The only restriction is that all the `strict` include relations should be placed before the non-strict ones, as `MATCH` can't follow `OPTIONAL MATCH`

All tests are passing